### PR TITLE
fix: override stdout rows to prevent terminal clearing

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -18,7 +18,6 @@ const data = [
   },
   {
     age: 22,
-    bigData: 'c'.repeat(30),
     employed: ansis.bold('false'),
     id: terminalLink('51786', 'https://example.com/51786'),
     name: 'Charlie',

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -457,8 +457,10 @@ class Output {
   public stream: Stream | WriteStream
 
   public constructor() {
-    const fd = process.env.OCLIF_TABLE_FD ? Number(process.env.OCLIF_TABLE_FD) : 0
-    this.stream = process.env.NODE_ENV === 'test' ? process.stdout : new Stream(fd)
+    this.stream =
+      (process.platform === 'win32' && process.env.npm_lifecycle_script === 'wireit') || process.env.NODE_ENV === 'test'
+        ? process.stdout
+        : new Stream(process.env.OCLIF_TABLE_FD ? Number(process.env.OCLIF_TABLE_FD) : process.stdout.fd)
   }
 
   public maybePrintLastFrame() {

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -430,6 +430,12 @@ export function Skeleton(props: React.PropsWithChildren & {readonly height?: num
  * the desired effect in powershell.
  */
 class Stream extends WriteStream {
+  // Override the rows so that ink doesn't clear the entire terminal when
+  // unmounting the component and the height of the output is greater than
+  // the height of the terminal
+  // https://github.com/vadimdemedes/ink/blob/v5.0.1/src/ink.tsx#L174
+  // This might be a bad idea but it works.
+  public rows = 10_000
   private frames: string[] = []
 
   public lastFrame(): string | undefined {

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -457,6 +457,8 @@ class Output {
   public stream: Stream | WriteStream
 
   public constructor() {
+    // Use process.stdout if NODE_ENV is `test` OR if tests are being run by wireit on windows (windows + tests run by wireit
+    // are problematic for an unknown reason)
     this.stream =
       (process.platform === 'win32' && process.env.npm_lifecycle_script === 'wireit') || process.env.NODE_ENV === 'test'
         ? process.stdout


### PR DESCRIPTION
### Prevent prior output from being cleared
ink [clears the terminal](https://github.com/vadimdemedes/ink/blob/v5.0.1/src/ink.tsx#L174) when the height of the output exceeds the height of the terminal. This means that any output in the terminal prior to the rendering of the table is removed. So to prevent this, we override the number of rows on the stdout stream so that the height of the terminal is always greater than the height of the table.

This should be fine since the table is only rendered once.

### Windows tests run by `wireit`

For some unknown reason using our wrapper stream on windows is problematic when tests are run by `wireit`. To avoid this, we detect this situation and use `process.stdout` instead