### PR TITLE
feat: dont use ink when size in greater than 10k

### DIFF
--- a/src/table.tsx
+++ b/src/table.tsx
@@ -30,6 +30,7 @@ import {
   getHeadings,
   intersperse,
   maybeStripAnsi,
+  shouldUsePlainTable,
   sortData,
 } from './utils.js'
 
@@ -488,7 +489,7 @@ class Output {
   }
 }
 
-function renderTableInChunks<T extends Record<string, unknown>>(props: TableOptions<T>): void {
+function renderPlainTable<T extends Record<string, unknown>>(props: TableOptions<T>): void {
   const {columns, headings, processedData, title} = setup(props)
 
   if (title) console.log(title)
@@ -542,8 +543,8 @@ function renderTableInChunks<T extends Record<string, unknown>>(props: TableOpti
  */
 export function printTable<T extends Record<string, unknown>>(options: TableOptions<T>): void {
   const limit = Number.parseInt(env.OCLIF_TABLE_LIMIT ?? env.SF_TABLE_LIMIT ?? '10000', 10) ?? 10_000
-  if (options.data.length >= limit) {
-    renderTableInChunks(options)
+  if (options.data.length >= limit || shouldUsePlainTable()) {
+    renderPlainTable(options)
     return
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,8 +185,18 @@ function isTruthy(value: string | undefined): boolean {
   return value !== '0' && value !== 'false'
 }
 
-// Inspired by https://github.com/sindresorhus/is-in-ci
+/**
+ * Determines whether the plain text table should be used.
+ *
+ * If the OCLIF_TABLE_SKIP_CI_CHECK environment variable is set to a truthy value, the CI check will be skipped.
+ *
+ * If the CI environment variable is set, the plain text table will be used.
+ *
+ * @returns {boolean} True if the plain text table should be used, false otherwise.
+ */
 export function shouldUsePlainTable(): boolean {
+  if (env.OCLIF_TABLE_SKIP_CI_CHECK && isTruthy(env.OCLIF_TABLE_SKIP_CI_CHECK)) return false
+  // Inspired by https://github.com/sindresorhus/is-in-ci
   if (
     isTruthy(env.CI) &&
     ('CI' in env || 'CONTINUOUS_INTEGRATION' in env || Object.keys(env).some((key) => key.startsWith('CI_')))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import {camelCase, capitalCase, constantCase, kebabCase, pascalCase, sentenceCase, snakeCase} from 'change-case'
 import {orderBy} from 'natural-orderby'
+import {env} from 'node:process'
 import stripAnsi from 'strip-ansi'
 
 import {Column, ColumnProps, Config, Sort} from './types.js'
@@ -178,4 +179,18 @@ export function maybeStripAnsi<T extends Record<string, unknown>[]>(data: T, noS
   }
 
   return newData as T
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return value !== '0' && value !== 'false'
+}
+
+// Inspired by https://github.com/sindresorhus/is-in-ci
+export function shouldUsePlainTable(): boolean {
+  if (
+    isTruthy(env.CI) &&
+    ('CI' in env || 'CONTINUOUS_INTEGRATION' in env || Object.keys(env).some((key) => key.startsWith('CI_')))
+  )
+    return true
+  return false
 }

--- a/test/table.test.tsx
+++ b/test/table.test.tsx
@@ -10,6 +10,8 @@ import {Cell, Header, Skeleton, Table, formatTextWithMargins, printTable} from '
 
 config.truncateThreshold = 0
 
+process.env.OCLIF_TABLE_SKIP_CI_CHECK = 'true'
+
 // Helpers -------------------------------------------------------------------
 
 const skeleton = (v: string) => <Skeleton>{v}</Skeleton>


### PR DESCRIPTION
Don't use ink to render the table when the size of the table is greater than 10k rows (configurable with `OCLIF_TABLE_LIMIT` env var). This means that _no_ styling or other features will be applied but it prevents possible memory issues on older/slower machines

Never use ink to render table in CI (unless `OCLIF_TABLE_SKIP_CI_CHECK` env var is truthy)

@W-16736186@