### PR TITLE
fix: improve table width calculation

### DIFF
--- a/examples/long-column-names.ts
+++ b/examples/long-column-names.ts
@@ -1,0 +1,18 @@
+import {printTable} from '../src/index.js'
+
+const height = 10
+const data = Array.from({length: height}, (_, i) => ({age: i, name: `Foo ${i}`}))
+
+printTable({
+  columns: [
+    {key: 'name', name: 'Name'.repeat(100)},
+    {key: 'age', name: 'Age'.repeat(100)},
+  ],
+  data,
+  headerOptions: {
+    formatter: 'capitalCase',
+  },
+  horizontalAlignment: 'center',
+  title: 'Long Column Names',
+  titleOptions: {bold: true},
+})

--- a/test/table.test.tsx
+++ b/test/table.test.tsx
@@ -376,49 +376,49 @@ describe('Table', () => {
           {skeleton('┌')}
           {skeleton('──────')}
           {skeleton('┬')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┐')}
         </Box>
         <Box>
           {skeleton('│')}
           {header(' name ')}
           {skeleton('│')}
-          {header(' id              ')}
+          {header(' id                  ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('├')}
           {skeleton('──────')}
           {skeleton('┼')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┤')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell(' Foo  ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiii… ')}
+          {cell(' iiiiiiiiiiiiiiiiii… ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('├')}
           {skeleton('──────')}
           {skeleton('┼')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┤')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell(' Bar  ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiii… ')}
+          {cell(' iiiiiiiiiiiiiiiiii… ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('└')}
           {skeleton('──────')}
           {skeleton('┴')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┘')}
         </Box>
       </>,
@@ -441,105 +441,91 @@ describe('Table', () => {
           {skeleton('┌')}
           {skeleton('──────')}
           {skeleton('┬')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┐')}
         </Box>
         <Box>
           {skeleton('│')}
           {header(' name ')}
           {skeleton('│')}
-          {header(' id              ')}
+          {header(' id                  ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('├')}
           {skeleton('──────')}
           {skeleton('┼')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┤')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell(' Foo  ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
-          {skeleton('│')}
-        </Box>
-        <Box>
-          {skeleton('│')}
-          {cell('      ')}
-          {skeleton('│')}
-          {cell(' iiiiiiiiii      ')}
+          {cell(' iiiiiiiiiiiii       ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('├')}
           {skeleton('──────')}
           {skeleton('┼')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┤')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell(' Bar  ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
+          {cell(' iiiiiiiiiiiiiiiiiii ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('│')}
           {cell('      ')}
           {skeleton('│')}
-          {cell(' iiiiiiiiiiiiiii ')}
-          {skeleton('│')}
-        </Box>
-        <Box>
-          {skeleton('│')}
-          {cell('      ')}
-          {skeleton('│')}
-          {cell(' iiiiiiiiii      ')}
+          {cell(' iiiiiiiiiiiii       ')}
           {skeleton('│')}
         </Box>
         <Box>
           {skeleton('└')}
           {skeleton('──────')}
           {skeleton('┴')}
-          {skeleton('─────────────────')}
+          {skeleton('─────────────────────')}
           {skeleton('┘')}
         </Box>
       </>,


### PR DESCRIPTION
- We were double counting the padding when calculating the table width. This prevented the table from taking up the entire width of the terminal 
- Reduce column width down to `3 + padding * 2` if reducing down to `header.length + padding * 2` doesn't reduce the table enough to fit in the terminal