### PR TITLE
fix(W-17749478): revert regression caused by eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default [
       'react/jsx-tag-spacing': 'off',
       'unicorn/no-array-reduce': 'off',
       'unicorn/prefer-array-find': 'off',
+      'unicorn/prefer-math-min-max': 'off',
       'unicorn/prefer-module': 'off',
     },
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/table/issues",
   "dependencies": {
-    "@oclif/core": "^4",
     "@types/react": "^18.3.12",
     "change-case": "^5.4.4",
     "cli-truncate": "^4.0.0",
@@ -19,6 +18,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^19",
     "@eslint/compat": "^1.2.6",
+    "@oclif/core": "^4",
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^4.1.8",
     "@types/chai": "^4.3.16",

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -41,7 +41,7 @@ import {
  */
 function determineWidthToUse<T>(columns: Column<T>[], maxWidth: number, width: number | undefined): number {
   const tableWidth = columns.map((c) => c.width).reduce((a, b) => a + b, 0) + columns.length + 1
-  return width ?? Math.max(tableWidth, maxWidth)
+  return width ?? (tableWidth < maxWidth ? maxWidth : tableWidth)
 }
 
 function determineTruncatePosition(overflow: Overflow): 'start' | 'middle' | 'end' {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export function getColumns<T extends Record<string, unknown>>(config: Config<T>,
 
       const minWidth = calcMinWidth(largestColumn)
       const difference = tableWidth - maxWidth
-      const newWidth = Math.max(largestColumn.width - difference, minWidth)
+      const newWidth = largestColumn.width - difference < minWidth ? minWidth : largestColumn.width - difference
       largestColumn.width = newWidth
       tableWidth = calculateTableWidth(widths)
       seen.add(largestColumn.key)

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,12 +350,12 @@
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
 "@oclif/core@^4":
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.2.5.tgz#6b51e1db17272204b2431fee3eba93a21d59ebbe"
-  integrity sha512-bdXOojq8GaPnWnDgVOw030JlUROJEiDLXiV3XUUGUQDEp6YpVQvEYLIrUsEvyfASU3z3FGg3DC9k0kprcOYdhw==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.2.6.tgz#f2f1696be03a815a4c391504312f90fce29fbb4e"
+  integrity sha512-agk1Tlm7qMemWx+qq5aNgkYwX2JCkoVP4M0ruFveJrarmdUPbKZTMW1j/eg8lNKZh1sp68ytZyKhYXYEfRPcww==
   dependencies:
     ansi-escapes "^4.3.2"
-    ansis "^3.9.0"
+    ansis "^3.10.0"
     clean-stack "^3.0.1"
     cli-spinners "^2.9.2"
     debug "^4.4.0"
@@ -939,9 +939,9 @@ assertion-error@^1.1.0:
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 async@^3.2.3:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
-  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 auto-bind@^5.0.1:
   version "5.0.1"
@@ -2201,7 +2201,18 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9, fast-glob@^3.3.2:
+fast-glob@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
+fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==


### PR DESCRIPTION
Revert change made by new eslint config that caused incorrect width calculation when piping to a file

**QA**
link changes to CLI
`sf package version list --target-dev-hub devhub --verbose -p 0HoB0000000TODeKAO > output.txt`

https://github.com/forcedotcom/cli/issues/3206
@W-17749478@