### PR TITLE
fix(W-18763150): width calculation when no process.stdout.columns

### DIFF
--- a/examples/multiline.ts
+++ b/examples/multiline.ts
@@ -1,0 +1,33 @@
+import {printTable, TableOptions} from '../src/index.js'
+
+const data = [
+  {
+    arguments: 'defaultDevHub: true\ndirectory: /workspace',
+    model: 'OpenAI GPT35Turbo',
+    response: '',
+    tool: 'sf-get-username',
+  },
+  {
+    arguments: 'defaultDevHub: true\ndirectory: /Users/username/salesforce-projects',
+    model: 'OpenAI GPT4OmniMini',
+    response: '',
+    tool: 'sf-get-username',
+  },
+  {
+    arguments: 'directory: /Users/antml\n defaultDevHub: true',
+    model: 'Anthropic Claude 4 Sonnet',
+    response: "I'll help you find your default dev hub username. Let me check your Salesforce configuration.",
+    tool: 'sf-get-username',
+  },
+]
+
+const basic: TableOptions<(typeof data)[number]> = {
+  borderStyle: 'all',
+  columns: ['model', 'response', 'tool', 'arguments'],
+  data,
+  overflow: 'wrap',
+  title: 'Multiline Table',
+  verticalAlignment: 'center',
+}
+
+printTable(basic)

--- a/examples/no-width-table.ts
+++ b/examples/no-width-table.ts
@@ -16,7 +16,6 @@ printTable({
   headerOptions: {
     formatter: 'capitalCase',
   },
-  noStyle: true,
   overflow: 'wrap',
   title: 'process.stdout.columns is 0',
   titleOptions: {bold: true},
@@ -30,7 +29,6 @@ printTable({
   headerOptions: {
     formatter: 'capitalCase',
   },
-  noStyle: true,
   overflow: 'wrap',
   title: 'process.stdout.columns is undefined',
   titleOptions: {bold: true},

--- a/examples/no-width-table.ts
+++ b/examples/no-width-table.ts
@@ -1,0 +1,37 @@
+import {printTable} from '../src/index.js'
+
+const data = [
+  {
+    actual: 'This is a string of the actual test results. ',
+    expected: 'This is a long string of the expected test results. ',
+    result: 'Passed',
+    test: 'Topic',
+  },
+]
+
+process.stdout.columns = 0
+printTable({
+  columns: ['test', 'result', 'expected', 'actual'],
+  data,
+  headerOptions: {
+    formatter: 'capitalCase',
+  },
+  noStyle: true,
+  overflow: 'wrap',
+  title: 'process.stdout.columns is 0',
+  titleOptions: {bold: true},
+})
+
+// @ts-expect-error for testing
+process.stdout.columns = undefined
+printTable({
+  columns: ['test', 'result', 'expected', 'actual'],
+  data,
+  headerOptions: {
+    formatter: 'capitalCase',
+  },
+  noStyle: true,
+  overflow: 'wrap',
+  title: 'process.stdout.columns is undefined',
+  titleOptions: {bold: true},
+})

--- a/examples/overflow.ts
+++ b/examples/overflow.ts
@@ -1,7 +1,9 @@
 import {printTable} from '../src/index.js'
 
 const description =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'.repeat(
+    5,
+  )
 
 const data = [
   {

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -27,6 +27,7 @@ import {
   determineConfiguredWidth,
   determineWidthOfWrappedText,
   getColumns,
+  getColumnWidth,
   getHeadings,
   intersperse,
   maybeStripAnsi,
@@ -431,7 +432,7 @@ const createStdout = (): FakeStdout => {
   // https://github.com/vadimdemedes/ink/blob/v5.0.1/src/ink.tsx#L174
   // This might be a bad idea but it works.
   stdout.rows = 10_000
-  stdout.columns = process.stdout.columns ?? 80
+  stdout.columns = getColumnWidth()
   const frames: string[] = []
 
   stdout.write = (data: string) => {
@@ -568,8 +569,7 @@ export function printTables<T extends Record<string, unknown>[]>(
   const output = new Output()
   const leftMargin = options?.marginLeft ?? options?.margin ?? 0
   const rightMargin = options?.marginRight ?? options?.margin ?? 0
-  const columns = process.stdout.columns - (leftMargin + rightMargin)
-
+  const columns = getColumnWidth() - (leftMargin + rightMargin)
   const processed = tables.map((table) => ({
     ...table,
     // adjust maxWidth to account for margin and columnGap

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -113,7 +113,8 @@ export function formatTextWithMargins({
   const valueWithNoZeroWidthChars = String(value).replaceAll('​', ' ')
   const spaceForText = width - padding * 2
 
-  if (stripAnsi(valueWithNoZeroWidthChars).length <= spaceForText) {
+  // Handle the simple case where text fits within the available space and doesn't contain any newlines.
+  if (stripAnsi(valueWithNoZeroWidthChars).length <= spaceForText && !valueWithNoZeroWidthChars.includes('\n')) {
     const spaces = width - stripAnsi(valueWithNoZeroWidthChars).length
     return {
       text: valueWithNoZeroWidthChars,
@@ -121,6 +122,7 @@ export function formatTextWithMargins({
     }
   }
 
+  // Handle the case where the text needs to be wrapped.
   if (overflow === 'wrap') {
     const wrappedText = wrapAnsi(valueWithNoZeroWidthChars, spaceForText, {
       hard: true,
@@ -159,6 +161,7 @@ export function formatTextWithMargins({
     }
   }
 
+  // Handle the case where the text needs to be truncated.
   const text = cliTruncate(valueWithNoZeroWidthChars.replaceAll('\n', ' '), spaceForText, {
     position: determineTruncatePosition(overflow),
   })

--- a/test/table.test.tsx
+++ b/test/table.test.tsx
@@ -718,4 +718,80 @@ describe('printTable compatibility with @oclif/test', () => {
     )
     expect(stdout).to.equal(expected)
   })
+
+  it('prints full table with no set width', async () => {
+    console.log(process.stdout.columns)
+    const data = [
+      {name: 'Foo', age: '1'.repeat(60)},
+      {name: 'Bar', age: '2'.repeat(60)},
+    ]
+
+    const expected = `┌──────┬──────────────────────────────────────────────────────────────┐
+│ name │ age                                                          │
+├──────┼──────────────────────────────────────────────────────────────┤
+│ Foo  │ 111111111111111111111111111111111111111111111111111111111111 │
+├──────┼──────────────────────────────────────────────────────────────┤
+│ Bar  │ 222222222222222222222222222222222222222222222222222222222222 │
+└──────┴──────────────────────────────────────────────────────────────┘
+
+`
+
+    const {stdout} = await captureOutput(async () =>
+      printTable({
+        data,
+        columns: ['name', 'age'],
+      }),
+    )
+    expect(stdout).to.equal(expected)
+  })
+
+  it('should use natural width of 80 if process.stdout.columns is 0', async () => {
+    const backupColumns = process.stdout.columns
+    process.stdout.columns = 0
+    const data = [
+      {name: 'Foo', age: '1'.repeat(100)},
+      {name: 'Bar', age: '2'.repeat(100)},
+    ]
+
+    const {stdout} = await captureOutput(async () =>
+      printTable({
+        data,
+        columns: ['name', 'age'],
+      }),
+    )
+    expect(stdout.length).to.equal(785)
+
+    process.stdout.columns = backupColumns
+  })
+
+  it('should respect the OCLIF_TABLE_COLUMN_OVERRIDE env var', async () => {
+    const backupColumns = process.stdout.columns
+    process.stdout.columns = 0
+    process.env.OCLIF_TABLE_COLUMN_OVERRIDE = '50'
+    const data = [
+      {name: 'Foo', age: '1'.repeat(100)},
+      {name: 'Bar', age: '2'.repeat(100)},
+    ]
+
+    const expected = `┌──────┬─────────────────────────────────────────┐
+│ name │ age                                     │
+├──────┼─────────────────────────────────────────┤
+│ Foo  │ 11111111111111111111111111111111111111… │
+├──────┼─────────────────────────────────────────┤
+│ Bar  │ 22222222222222222222222222222222222222… │
+└──────┴─────────────────────────────────────────┘
+
+`
+
+    const {stdout} = await captureOutput(async () =>
+      printTable({
+        data,
+        columns: ['name', 'age'],
+      }),
+    )
+    expect(stdout).to.equal(expected)
+
+    delete process.env.OCLIF_TABLE_COLUMN_OVERRIDE
+    process.stdout.columns = backupColumns
+  })
 })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -75,7 +75,7 @@ describe('should get the correct column width', () => {
   it('should return the value of process.stdout.columns', () => {
     if (process.env.CI && !process.stdout.columns) {
       // In GHA process.stdout.columns is undefined
-      expect(getColumnWidth()).to.equal(80)
+      expect(getColumnWidth()).to.equal(undefined)
     } else {
       const currentColumns = process.stdout.columns
       expect(getColumnWidth()).to.equal(currentColumns)

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,6 +1,6 @@
 import {config, expect} from 'chai'
 
-import {intersperse, sortData} from '../src/utils.js'
+import {getColumnWidth, intersperse, sortData} from '../src/utils.js'
 
 config.truncateThreshold = 0
 
@@ -62,5 +62,23 @@ describe('sortData', () => {
       {age: 20, name: 'Amy'},
     ]
     expect(sortData(data, sort)).to.deep.equal(expected)
+  })
+})
+
+describe('should get the correct column width', () => {
+  it('should return the value of OCLIF_TABLE_COLUMN_OVERRIDE', () => {
+    process.env.OCLIF_TABLE_COLUMN_OVERRIDE = '100'
+    expect(getColumnWidth()).to.equal(100)
+    delete process.env.OCLIF_TABLE_COLUMN_OVERRIDE
+  })
+
+  it('should return the value of process.stdout.columns', () => {
+    if (process.env.CI && !process.stdout.columns) {
+      // In GHA process.stdout.columns is undefined
+      expect(getColumnWidth()).to.equal(80)
+    } else {
+      const currentColumns = process.stdout.columns
+      expect(getColumnWidth()).to.equal(currentColumns)
+    }
   })
 })


### PR DESCRIPTION
There are scenarios (particularly in CI environments) where `process.stdout.columns` could be `0` or `undefined`

Whenever this happens, I decided to render the table with its natural width instead of defaulting to 80 columns. If we default to 80 columns, then [sf's integration tests fail](https://github.com/salesforcecli/cli/actions/runs/14436338418/job/40512969397) because the tables become too compact. If allowing the table to be its natural width renders poorly for users, they can use the `OCLIF_TABLE_COLUMN_OVERRIDE` to override `process.stdout.columns`.

This PR also contains a small fix for short, multiline strings causing borders to be misaligned (see examples/multiline.ts) for an example.

https://github.com/forcedotcom/cli/issues/3317 
https://github.com/forcedotcom/cli/issues/3252
@W-18763150@