### PR TITLE
fix: don't strip tab whitespaces when wrapping

### DIFF
--- a/examples/json-entry.ts
+++ b/examples/json-entry.ts
@@ -51,5 +51,5 @@ const data = [
 
 ]
 
-const table = makeTable({data, horizontalAlignment:'left', overflow: 'wrap', preserveWhitespace:true})
+const table = makeTable({data, horizontalAlignment:'left',overflow: 'wrap', title: 'Employees', trimWhitespace: false})
 console.log(table);

--- a/examples/json-entry.ts
+++ b/examples/json-entry.ts
@@ -1,6 +1,6 @@
 import {ux} from "@oclif/core";
 
-import {makeTable } from '../src/index.js'
+import {makeTable } from '../src'
 
 
 
@@ -50,6 +50,9 @@ const data = [
     }
 
 ]
+
+const trimmedTable = makeTable({data, horizontalAlignment:'left',overflow: 'wrap', title: 'Employees', trimWhitespace: true})
+console.log(trimmedTable);
 
 const table = makeTable({data, horizontalAlignment:'left',overflow: 'wrap', title: 'Employees', trimWhitespace: false})
 console.log(table);

--- a/examples/json-entry.ts
+++ b/examples/json-entry.ts
@@ -1,0 +1,55 @@
+import {ux} from "@oclif/core";
+
+import {makeTable } from '../src/index.js'
+
+
+
+const data = [
+    { data:
+            ux.colorizeJson({
+                "function": {
+                    "input": {
+                        "objectApiName": "Account",
+                        "recordName": "Acme"
+                    },
+                    "name": "Willie",
+                    "output": {
+                        "additionalContext": [
+                            {
+                                "description": "engineer",
+                                "id": null,
+                                "name": "Willie",
+                                "schema": null,
+                                "type": "JSON",
+                            }
+                        ]
+                    }
+                }
+            })},
+    {
+        data: ux.colorizeJson({
+                "function": {
+                    "input": {
+                        "objectApiName": "Account",
+                        "recordName": "Acme"
+                    },
+                    "name": "Mike",
+                    "output": {
+                        "additionalContext": [
+                            {
+                                "description": "engineer",
+                                "id": null,
+                                "name": "Mike",
+                                "schema": null,
+                                "type": "JSON",
+                            }
+                        ]
+                    }
+                }
+            })
+    }
+
+]
+
+const table = makeTable({data, horizontalAlignment:'left', overflow: 'wrap', preserveWhitespace:true})
+console.log(table);

--- a/examples/make-table.ts
+++ b/examples/make-table.ts
@@ -33,6 +33,7 @@ const basic: TableOptions<(typeof data)[number]> = {
     color: '#905de8',
     formatter: 'sentenceCase',
   },
+  preserveWhitespace: true,
   sort: {
     id: 'desc',
   },

--- a/examples/make-table.ts
+++ b/examples/make-table.ts
@@ -33,10 +33,10 @@ const basic: TableOptions<(typeof data)[number]> = {
     color: '#905de8',
     formatter: 'sentenceCase',
   },
-  preserveWhitespace: true,
   sort: {
     id: 'desc',
   },
+  trimWhitespace: true,
   verticalAlignment: 'center',
 }
 

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -126,7 +126,7 @@ export function formatTextWithMargins({
   if (overflow === 'wrap') {
     const wrappedText = wrapAnsi(valueWithNoZeroWidthChars, spaceForText, {
       hard: true,
-      trim: true,
+      trim: false,
       wordWrap: true,
     }).replace(/^\n/, '') // remove leading newline (wrapAnsi adds it to emojis)
     const {marginLeft, marginRight} = calculateMargins(width - determineWidthOfWrappedText(stripAnsi(wrappedText)))

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -69,14 +69,16 @@ export function formatTextWithMargins({
   horizontalAlignment,
   overflow,
   padding,
+  trimWhitespace = true,
   value,
-  width,
+  width
 }: {
   overflow: Overflow
   value: unknown
   width: number
   padding: number
   horizontalAlignment: HorizontalAlignment
+  trimWhitespace?: boolean
 }): {
   text: string
   marginLeft: number
@@ -126,7 +128,7 @@ export function formatTextWithMargins({
   if (overflow === 'wrap') {
     const wrappedText = wrapAnsi(valueWithNoZeroWidthChars, spaceForText, {
       hard: true,
-      trim: false,
+      trim: trimWhitespace,
       wordWrap: true,
     }).replace(/^\n/, '') // remove leading newline (wrapAnsi adds it to emojis)
     const {marginLeft, marginRight} = calculateMargins(width - determineWidthOfWrappedText(stripAnsi(wrappedText)))
@@ -325,7 +327,7 @@ function row<T extends Record<string, unknown>>(config: RowConfig): (props: RowP
 
   return (props) => {
     const data = props.columns.map((column, colI) => {
-      const {horizontalAlignment, overflow, padding, verticalAlignment, width} = column
+      const {horizontalAlignment, overflow, padding, verticalAlignment, width, } = column
       const value = props.data[column.column]
 
       if (value === undefined || value === null) {
@@ -343,6 +345,7 @@ function row<T extends Record<string, unknown>>(config: RowConfig): (props: RowP
         horizontalAlignment,
         overflow,
         padding,
+        trimWhitespace : false,
         value,
         width,
       })
@@ -478,6 +481,7 @@ function renderPlainTable<T extends Record<string, unknown>>(props: TableOptions
       horizontalAlignment,
       overflow,
       padding,
+      trimWhitespace: props.preserveWhitespace ?? false,
       value: headings[column.column] ?? column.column,
       width,
     })
@@ -524,6 +528,7 @@ function renderPlainTable<T extends Record<string, unknown>>(props: TableOptions
         horizontalAlignment,
         overflow,
         padding,
+        trimWhitespace: props.preserveWhitespace ?? false,
         value,
         width,
       })

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -185,6 +185,7 @@ function setupTable<T extends Record<string, unknown>>(props: TableOptions<T>) {
     padding = 1,
     sort,
     title,
+    trimWhitespace,
     verticalAlignment = 'top',
     width,
   } = props
@@ -206,6 +207,7 @@ function setupTable<T extends Record<string, unknown>>(props: TableOptions<T>) {
     maxWidth: tableWidth ?? determineConfiguredWidth(maxWidth),
     overflow,
     padding,
+    trimWhitespace,
     verticalAlignment,
     width: tableWidth,
   }
@@ -223,6 +225,7 @@ function setupTable<T extends Record<string, unknown>>(props: TableOptions<T>) {
     borderProps,
     cell: Cell,
     skeleton: BORDER_SKELETONS[config.borderStyle].data,
+    trimWhitespace
   })
 
   const footerComponent = row<T>({
@@ -323,11 +326,11 @@ export function Table<T extends Record<string, unknown>>(props: TableOptions<T>)
  */
 function row<T extends Record<string, unknown>>(config: RowConfig): (props: RowProps<T>) => React.ReactNode {
   // This is a component builder. We return a function.
-  const {borderProps, skeleton} = config
+  const {borderProps, skeleton, trimWhitespace} = config
 
   return (props) => {
     const data = props.columns.map((column, colI) => {
-      const {horizontalAlignment, overflow, padding, verticalAlignment, width, } = column
+      const {horizontalAlignment, overflow, padding, verticalAlignment, width} = column
       const value = props.data[column.column]
 
       if (value === undefined || value === null) {
@@ -345,7 +348,7 @@ function row<T extends Record<string, unknown>>(config: RowConfig): (props: RowP
         horizontalAlignment,
         overflow,
         padding,
-        trimWhitespace : false,
+        trimWhitespace,
         value,
         width,
       })

--- a/src/table.tsx
+++ b/src/table.tsx
@@ -481,7 +481,7 @@ function renderPlainTable<T extends Record<string, unknown>>(props: TableOptions
       horizontalAlignment,
       overflow,
       padding,
-      trimWhitespace: props.preserveWhitespace ?? false,
+      trimWhitespace: props.trimWhitespace,
       value: headings[column.column] ?? column.column,
       width,
     })
@@ -528,7 +528,7 @@ function renderPlainTable<T extends Record<string, unknown>>(props: TableOptions
         horizontalAlignment,
         overflow,
         padding,
-        trimWhitespace: props.preserveWhitespace ?? false,
+        trimWhitespace: props.trimWhitespace,
         value,
         width,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,10 +203,10 @@ export type TableOptions<T extends Record<string, unknown>> = {
    */
   title?: string
   /**
-   * Whether to preserve whitespace in row content
-   * default: false
+   * Whether or not to trim the whitespace of row content
+   * default: true
    */
-  preserveWhitespace?: boolean
+  trimWhitespace?: boolean
   /**
    * Styling options for the title of the table.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,11 @@ export type TableOptions<T extends Record<string, unknown>> = {
    */
   title?: string
   /**
+   * Whether to preserve whitespace in row content
+   * default: false
+   */
+  preserveWhitespace?: boolean
+  /**
    * Styling options for the title of the table.
    */
   titleOptions?: TextOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,7 @@ export type Config<T> = {
   maxWidth: number
   overflow: Overflow
   headerOptions: HeaderOptions
+  trimWhitespace: boolean | undefined
   borderStyle: BorderStyle
   horizontalAlignment: HorizontalAlignment
   verticalAlignment: VerticalAlignment
@@ -250,6 +251,11 @@ export type RowConfig = {
     cross: string
     line: string
   }
+  /**
+   * Whether or not to trim the whitespace of row content
+   * default: true
+   */
+  trimWhitespace?: boolean
   props?: Record<string, unknown>
   borderProps: {
     color: SupportedColor | undefined

--- a/test/table.test.tsx
+++ b/test/table.test.tsx
@@ -582,8 +582,29 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
         }),
       ).to.deep.equal({
         marginLeft: 1,
+        marginRight: 1,
+        text: "Lorem ipsum dolor sit amet, consectetur         \n adipi                                           \n scing elit. Sed do eiusmod tempor incididunt ut \n labore et dolore magna aliqua.                  "
+      })
+    })
+
+      it('formats multiline string with tabs', () => {
+      expect(
+        formatTextWithMargins({
+          horizontalAlignment: 'left',
+          overflow: 'wrap',
+          padding: 1,
+          value: `{
+            key: "value",
+            object: {
+                key1: "v1"
+            }
+          }`,
+          width: 20,
+        }),
+      ).to.deep.equal({
+        marginLeft: 1,
         marginRight: 2,
-        text: 'Lorem ipsum dolor sit amet, consectetur        \n adipi                                          \n scing elit. Sed do eiusmod tempor incididunt ut\n labore et dolore magna aliqua.                 ',
+        text: "{                \n             key: \n \"value\",         \n                  \n object: {        \n                  \n key1: \"v1\"       \n             }    \n           }      "
       })
     })
   })
@@ -604,6 +625,27 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
         text: 'Foo',
       })
     })
+
+      it('formats multiline string with tabs', () => {
+          expect(
+              formatTextWithMargins({
+                  horizontalAlignment: 'right',
+                  overflow: 'wrap',
+                  padding: 1,
+                  value: `{
+            key: "value",
+            object: {
+                key1: "v1"
+            }
+          }`,
+                  width: 20,
+              }),
+          ).to.deep.equal({
+              marginLeft: 2,
+              marginRight: 1,
+              text: "                {\n              key: \n           \"value\",\n                   \n          object: {\n                   \n         key1: \"v1\"\n                  }\n                  }"
+          })
+      })
 
     it('formats long string', () => {
       expect(
@@ -634,13 +676,35 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
         }),
       ).to.deep.equal({
         marginLeft: 1,
-        marginRight: 2,
-        text: '    Lorem ipsum dolor sit amet, consectetur      \n                      adipi                     \n scing elit. Sed do eiusmod tempor incididunt ut\n          labore et dolore magna aliqua.        ',
+        marginRight: 1,
+        text: "    Lorem ipsum dolor sit amet, consectetur      \n                      adipi                      \n scing elit. Sed do eiusmod tempor incididunt ut \n          labore et dolore magna aliqua.         "
       })
     })
   })
 
   describe('wrap + align right', () => {
+
+      it('formats multiline string with tabs', () => {
+          expect(
+              formatTextWithMargins({
+                  horizontalAlignment: 'right',
+                  overflow: 'wrap',
+                  padding: 1,
+                  value: `{
+            key: "value",
+            object: {
+                key1: "v1"
+            }
+          }`,
+                  width: 20,
+              }),
+          ).to.deep.equal({
+              marginLeft: 2,
+              marginRight: 1,
+              text: "                {\n              key: \n           \"value\",\n                   \n          object: {\n                   \n         key1: \"v1\"\n                  }\n                  }"
+          })
+      })
+
     it('formats short string', () => {
       expect(
         formatTextWithMargins({
@@ -685,9 +749,9 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
           width: 50,
         }),
       ).to.deep.equal({
-        marginLeft: 2,
+        marginLeft: 1,
         marginRight: 1,
-        text: '        Lorem ipsum dolor sit amet, consectetur\n                                            adipi\n  scing elit. Sed do eiusmod tempor incididunt ut\n                   labore et dolore magna aliqua.',
+        text:"         Lorem ipsum dolor sit amet, consectetur\n                                            adipi\n scing elit. Sed do eiusmod tempor incididunt ut \n                   labore et dolore magna aliqua.",
       })
     })
   })

--- a/test/table.test.tsx
+++ b/test/table.test.tsx
@@ -581,9 +581,9 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
           width: 50,
         }),
       ).to.deep.equal({
-        marginLeft: 1,
-        marginRight: 1,
-        text: "Lorem ipsum dolor sit amet, consectetur         \n adipi                                           \n scing elit. Sed do eiusmod tempor incididunt ut \n labore et dolore magna aliqua.                  "
+          marginLeft: 1,
+          marginRight: 2,
+          text: 'Lorem ipsum dolor sit amet, consectetur        \n adipi                                          \n scing elit. Sed do eiusmod tempor incididunt ut\n labore et dolore magna aliqua.                 ',
       })
     })
 
@@ -592,6 +592,7 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
         formatTextWithMargins({
           horizontalAlignment: 'left',
           overflow: 'wrap',
+          trimWhitespace: false,
           padding: 1,
           value: `{
             key: "value",
@@ -631,6 +632,7 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
               formatTextWithMargins({
                   horizontalAlignment: 'right',
                   overflow: 'wrap',
+                  trimWhitespace: false,
                   padding: 1,
                   value: `{
             key: "value",
@@ -676,8 +678,8 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
         }),
       ).to.deep.equal({
         marginLeft: 1,
-        marginRight: 1,
-        text: "    Lorem ipsum dolor sit amet, consectetur      \n                      adipi                      \n scing elit. Sed do eiusmod tempor incididunt ut \n          labore et dolore magna aliqua.         "
+        marginRight: 2,
+        text: '    Lorem ipsum dolor sit amet, consectetur      \n                      adipi                     \n scing elit. Sed do eiusmod tempor incididunt ut\n          labore et dolore magna aliqua.        ',
       })
     })
   })
@@ -690,6 +692,7 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
                   horizontalAlignment: 'right',
                   overflow: 'wrap',
                   padding: 1,
+                  trimWhitespace: false,
                   value: `{
             key: "value",
             object: {
@@ -749,9 +752,9 @@ scing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
           width: 50,
         }),
       ).to.deep.equal({
-        marginLeft: 1,
+        marginLeft: 2,
         marginRight: 1,
-        text:"         Lorem ipsum dolor sit amet, consectetur\n                                            adipi\n scing elit. Sed do eiusmod tempor incididunt ut \n                   labore et dolore magna aliqua.",
+        text: '        Lorem ipsum dolor sit amet, consectetur\n                                            adipi\n  scing elit. Sed do eiusmod tempor incididunt ut\n                   labore et dolore magna aliqua.',
       })
     })
   })


### PR DESCRIPTION
before: when wrapping text, it would strip white spaces and would make indented data hard to read

see: 
<img width="576" height="584" alt="image" src="https://github.com/user-attachments/assets/78c11d69-9ba9-4bb7-9eab-0bad8ca0b230" />


after:
<img width="654" height="596" alt="image" src="https://github.com/user-attachments/assets/fab9a005-8a2d-4f65-9b69-2ecbab3fa6ec" />

@W-19178921@
